### PR TITLE
added SetAll

### DIFF
--- a/app.go
+++ b/app.go
@@ -38,12 +38,8 @@ func writeByte(val int) {
 }
 
 func (bl Blinkt) Clear() {
-	r := 0
-	g := 0
-	b := 0
-	for i := 0; i < 8; i++ {
-		bl.SetPixel(i, r, g, b)
-	}
+	r, g, b := 0, 0, 0
+	bl.SetAll(r, g, b)
 }
 
 func (bl Blinkt) Show() {
@@ -62,6 +58,12 @@ func (bl Blinkt) Show() {
 		writeByte(r)
 	}
 	eof()
+}
+
+func (bl Blinkt) SetAll(r int, g int, b int) {
+	for i, _ := range bl.pixels {
+		bl.SetPixel(i, r, g, b)
+	}
 }
 
 func (bl Blinkt) SetPixel(p int, r int, g int, b int) {
@@ -90,7 +92,6 @@ func NewBlinkt(brightness int) Blinkt {
 type Blinkt struct {
 	pixels *[8][4]int
 }
-
 
 func init() {
 

--- a/app.go
+++ b/app.go
@@ -38,7 +38,9 @@ func writeByte(val int) {
 }
 
 func (bl Blinkt) Clear() {
-	r, g, b := 0, 0, 0
+	r := 0
+	g := 0
+	b := 0
 	bl.SetAll(r, g, b)
 }
 


### PR DESCRIPTION
This is an addition of a SetAll function which mirrors the capability of set_all in the python lib.  I've been using SetAll while investigating porting of the python examples to golang.

Very small change but helps keep the downstream code a little more succinct.